### PR TITLE
The client should also disconnect on close ... now it just stops cons…

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -87,9 +87,12 @@ Client.prototype.stop = function(callback) {
 
   self._consumeChannel.stop(function() {
     self._dispatchChannel.stop(function() {
-      if (callback) {
-        callback(null);
-      }
+      self._transport.disconnect(function(){
+        if (callback) {
+
+          callback(null);
+        }
+      });
     });
   });
 };


### PR DESCRIPTION
Well, if you call client close, the connections remains up, not also disconnects the transport. 

Assuming the that was a bug, this will fix it, if that was intended, a function like closeAndDisconnect should be implemented.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/kurtpattyn/kimbu/8)

<!-- Reviewable:end -->
